### PR TITLE
Add Tautulli media thumbnails support

### DIFF
--- a/config_example.json
+++ b/config_example.json
@@ -13,6 +13,10 @@
         "enable": true,
         "apiKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     },
+    "tautulli": {
+        "enable": false,
+        "url": "https://example.com"
+    },
     "discord": {
         "appId": 923857760897101855,
         "minimal": false

--- a/perplex.py
+++ b/perplex.py
@@ -260,6 +260,9 @@ class Perplex:
             # Default to image uploaded via Discord Developer Portal
             result["image"] = "movie"
             result["buttons"] = []
+            if self.config["tautulli"]["enable"]:
+                settings: Dict[str, Any] = self.config["tautulli"]
+                result["image"] = f"{settings['url']}/pms_image_proxy?img={active.thumbUrl}"       
         else:
             mId: int = metadata["id"]
             mType: str = metadata["media_type"]
@@ -299,6 +302,9 @@ class Perplex:
             # Default to image uploaded via Discord Developer Portal
             result["image"] = "tv"
             result["buttons"] = []
+            if self.config["tautulli"]["enable"]:
+                settings: Dict[str, Any] = self.config["tautulli"]
+                result["image"] = f"{settings['url']}/pms_image_proxy?img={active.grandparentThumb}"
         else:
             mId: int = metadata["id"]
             mType: str = metadata["media_type"]
@@ -326,6 +332,13 @@ class Perplex:
 
         # Default to image uploaded via Discord Developer Portal
         result["image"] = "music"
+        if self.config["tautulli"]["enable"]:
+            try:
+                settings: Dict[str, Any] = self.config["tautulli"]
+                result["image"] = f"{settings['url']}/pms_image_proxy?img={active.parentThumb}"
+            except:
+                pass
+            
         result["buttons"] = []
 
         logger.trace(result)


### PR DESCRIPTION
Hello! This is my very first pull request on GitHub, so please let me know what I can do to improve for next time!
I added support for [Tautulli's](https://tautulli.com) image proxy to use as thumbnail art for all media types. This is a fairly simple setup for those who already have a publicly-facing instance of Tautulli connected to their Plex servers, as all it requires is the URL of said instance.
Here are examples of it in action:
![image](https://user-images.githubusercontent.com/78718829/150623171-1f3a9253-dcc8-473e-863b-370fcb574a49.png)
![image](https://user-images.githubusercontent.com/78718829/150623172-83fab8b7-539e-4096-9961-f1003f4da3c5.png)
![image](https://user-images.githubusercontent.com/78718829/150623176-4985b21e-9cd6-49bd-8fbb-801c2859cf9e.png)
thank you so much for your work on Perplex!