### PR TITLE
Improved FetchMetadata, Adding Pause state, Fixed "(year)" in title

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Perplex is a Discord Rich Presence implementation for Plex.
 ## Features
 
 -   Modern and beautiful Rich Presence for movies, TV shows, and music.
--   [The Movie Database (TMDB)](https://www.themoviedb.org/) integration for enhanced media information.
+-   [The Movie Database (TMDB)](https://www.themoviedb.org/) or [Trakt.tv](https://www.trakt.tv/) integration for enhanced media information.
 -   Optional minimal mode for Rich Presence to hide granular information
 -   Lightweight console application that runs in the background.
 -   Support for two-factor authentication (2FA) at login.
@@ -25,6 +25,9 @@ Note: A Discord desktop client must be connected on the same device that Perplex
 2. Rename `config_example.json` to `config.json`, then provide the configurable values.
 3. Start Perplex: `python perplex.py`
 
+**Trakt**:
+You will need to create a new application on [Trakt.tv](https://trakt.tv/oauth/applications/new) to obtain a client ID. The application name and description can be anything you want. The application redirect URI must be `urn:ietf:wg:oauth:2.0:oob`.
+
 **Configurable Values:**
 
 -   `logging`:`severity`: Minimum [Loguru](https://loguru.readthedocs.io/en/stable/api/logger.html) severity level to display in the console (do not modify unless necessary).
@@ -35,5 +38,7 @@ Note: A Discord desktop client must be connected on the same device that Perplex
 -   `plex`:`users`: List of Plex users, in order of priority.
 -   `tmdb`:`enable`: `true` or `false` toggle for enhanced media information in Rich Presence.
 -   `tmdb`:`apiKey`: [TMDB API](https://www.themoviedb.org/settings/api) key (only used if `tmdb` `enable` is `true`).
+-   `trakt`:`enable`: `true` or `false` toggle for enhanced media information in Rich Presence.
+-   `trakt`:`clientId`: [Trakt API app](https://trakt.tv/oauth/applications/new) client ID (only used if `trakt` `enable` is `true`).
 -   `discord`:`appId`: Discord application ID (do not modify unless necessary).
 -   `discord`:`minimal`: `true` or `false` toggle for minimal media information in Rich Presence.

--- a/config_example.json
+++ b/config_example.json
@@ -13,6 +13,10 @@
         "enable": true,
         "apiKey": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     },
+    "trakt": {
+        "enabled": true,
+        "clientId": "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+    },
     "discord": {
         "appId": 923857760897101855,
         "minimal": false

--- a/perplex.py
+++ b/perplex.py
@@ -1,4 +1,5 @@
 import json
+import re
 import urllib.parse
 from datetime import datetime
 from pathlib import Path
@@ -391,6 +392,9 @@ class Perplex:
 
         settings: Dict[str, Any] = self.config["tmdb"]
         key: str = settings["apiKey"]
+
+        # if title has a "(year)" in it, removes it. https://github.com/EthanC/Perplex/issues/21
+        title = re.sub(r"\(\d{4}\)", "", title).strip()
 
         if settings["enable"]:
 


### PR DESCRIPTION
Added:
- You can use Trakt to more accurately find the media, get season poster (could add an option in config to choose between show, season, episode poster)
- Displays "Paused ⏸︎ | X%/Y min" when session is paused and shows progress (%) and duration of the media. Close #22

Changed:
- If Trakt is enabled or not, it will try to get tmdb guid to get data from the api and not do a title query
- Removes "(year)" in title. Fix #21
- README.md has Trakt setup indications and configuration values